### PR TITLE
Add Alibaba Cloud sizing script

### DIFF
--- a/alibaba/README.md
+++ b/alibaba/README.md
@@ -1,0 +1,34 @@
+# Prisma Cloud Alibaba Cloud License Sizing Script
+
+## Overview
+
+This document describes how to prepare for, and how to run the Prisma Cloud Alibaba Cloud License Sizing Script.
+
+## Prerequisites
+
+### Required Permissions
+
+The Alibaba Cloud account that is used to run the sizing script must have the required permissions to be able to collect sizing information.
+
+### Required Alibaba Cloud API/CLIs
+
+The below Alibaba Cloud APIs need to be enabled in order to gather information from Alibaba Cloud.
+
+* aliyun ecs DescribeRegions
+* aliyun ecs DescribeInstances
+
+## Running the Script
+
+Follow the steps below to run the Prisma Cloud Alibaba Cloud License Sizing Script.
+
+1. Download the sizing script to your local computer
+    1. [resource-count-abc.sh](resource-count-abc.sh)
+1. Log into your Alibaba Cloud Console
+1. Launch the Alibaba Cloud Cloud Shell
+1. Click on the cloud on the left side of the Cloud Shell window
+1. Select "Upload"
+1. Upload the sizing script to your Alibaba Cloud Shell
+1. Run the sizing script.
+    1. `chmod +x resource-count-abc.sh`
+    1. `./resource-count-abc.sh`
+1. Share the results with your Palo Alto Networks team

--- a/alibaba/resource-count-abc.sh
+++ b/alibaba/resource-count-abc.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# shellcheck disable=SC2102,SC2181,SC2207
+
+# Instructions:
+#
+# - Go to the Alibaba Cloud Console
+#
+# - Open Cloud Shell >_
+#
+# - Click on the cloud on the left side of the Cloud Shell window
+#
+# - Upload this script
+#
+# - Make this script executable:
+#   chmod +x resource-count-abc.sh
+#
+# - Run this script:
+#   ./resource-count-abc.sh
+#
+# This script may generate errors when:
+#
+# - The API/CLI is not enabled.
+# - You don't have permission to make the API/CLI calls.
+#
+# API/CLI used:
+#
+# - aliyun ecs DescribeRegions
+# - aliyun ecs DescribeInstances
+##########################################################################################
+
+##########################################################################################
+## Use of jq is required by this script.
+##########################################################################################
+
+if ! type "jq" > /dev/null; then
+  echo "Error: jq not installed or not in execution path, jq is required for script execution."
+  exit 1
+fi
+
+##########################################################################################
+## Utility functions.
+##########################################################################################
+
+abc_regions_list() {
+  # shellcheck disable=SC2086
+  RESULT=$(aliyun ecs DescribeRegions 2>/dev/null)
+  if [ $? -eq 0 ]; then
+    echo "${RESULT}"
+  fi
+}
+
+abc_compute_instances_list() {
+  if [ -z "${2}" ]; then
+    # shellcheck disable=SC2086
+    RESULT=$(aliyun ecs DescribeInstances --region "${1}" --Status Running --MaxResults 100 2>/dev/null)
+  else
+    # shellcheck disable=SC2086
+    RESULT=$(aliyun ecs DescribeInstances --region "${1}" --Status Running --MaxResults 100 --NextToken "${2}" 2>/dev/null)
+  fi
+  if [ $? -eq 0 ]; then
+    echo "${RESULT}"
+  fi
+}
+
+####
+
+get_regions() {
+  REGIONS=($(abc_regions_list | jq -r '.Regions.Region[].RegionId' 2>/dev/null | sort))
+  TOTAL_REGIONS=${#REGIONS[@]}
+}
+
+get_instance_count() {
+  COUNT=0
+  RESULT=$(abc_compute_instances_list "${1}")
+  COUNT=$(echo "${RESULT}" | jq -r '.TotalCount' 2>/dev/null)
+  echo "${COUNT}"
+}
+
+get_instance_count_via_pagination() {
+  COUNT=0
+  RESULT=$(abc_compute_instances_list "${1}")
+  INSTANCES=($(echo "${RESULT}" | jq -r '.Instances.Instance[].InstanceId' 2>/dev/null))
+  COUNT=$((COUNT + ${#INSTANCES[@]}))
+  NEXTTOKEN=$(echo "${RESULT}" | jq -r '.NextToken' 2>/dev/null)
+  while [ -n "${NEXTTOKEN}" ]; do
+    RESULT=$(abc_compute_instances_list "${1}" "${NEXTTOKEN}")
+    INSTANCES=($(echo "${RESULT}" | jq -r '.Instances.Instance[].InstanceId' 2>/dev/null))
+    COUNT=$((COUNT + ${#INSTANCES[@]}))
+    NEXTTOKEN=$(echo "${RESULT}" | jq -r '.NextToken' 2>/dev/null)
+  done
+  echo "${COUNT}"
+}
+
+##########################################################################################
+## Set or reset counters.
+##########################################################################################
+
+reset_local_counters() {
+  COMPUTE_INSTANCES_COUNT=0
+  WORKLOAD_COUNT=0
+}
+
+reset_global_counters() {
+  COMPUTE_INSTANCES_COUNT_GLOBAL=0
+  WORKLOAD_COUNT_GLOBAL=0
+}
+
+##########################################################################################
+## Iterate through the billable resource types.
+##########################################################################################
+
+count_resources() {
+  for ((REGION_INDEX=0; REGION_INDEX<=(TOTAL_REGIONS-1); REGION_INDEX++))
+  do
+    REGION="${REGIONS[$REGION_INDEX]}"
+
+    echo "###################################################################################"
+    echo "Processing Region: ${REGION}"
+
+    RESOURCE_COUNT=$(get_instance_count "${REGION}")
+    COMPUTE_INSTANCES_COUNT=$((COMPUTE_INSTANCES_COUNT + RESOURCE_COUNT))
+    echo "  Count of Compute Instances: ${COMPUTE_INSTANCES_COUNT}"
+
+    WORKLOAD_COUNT=$((COMPUTE_INSTANCES_COUNT + 0))
+    echo "Total billable resources for Region: ${WORKLOAD_COUNT}"
+    echo "###################################################################################"
+    echo ""
+
+    COMPUTE_INSTANCES_COUNT_GLOBAL=$((COMPUTE_INSTANCES_COUNT_GLOBAL + COMPUTE_INSTANCES_COUNT))
+    reset_local_counters
+  done
+
+  echo "###################################################################################"
+  echo "Totals"
+  echo "  Count of Compute Instances: ${COMPUTE_INSTANCES_COUNT_GLOBAL}"
+  WORKLOAD_COUNT_GLOBAL=$((COMPUTE_INSTANCES_COUNT_GLOBAL + 0))
+  echo "Total billable resources: ${WORKLOAD_COUNT_GLOBAL}"
+  echo "###################################################################################"
+}
+
+##########################################################################################
+# Allow shellspec to source this script.
+##########################################################################################
+
+${__SOURCED__:+return}
+
+##########################################################################################
+# Main.
+##########################################################################################
+
+get_regions
+reset_global_counters
+count_resources

--- a/spec/resource-count-abc_spec.sh
+++ b/spec/resource-count-abc_spec.sh
@@ -1,0 +1,115 @@
+# To use this test, call: shellspec spec/resource-count-abc_spec.sh
+
+Describe 'resource-count-abc'
+
+  ########################################################################################
+  # https://github.com/shellspec/shellspec#include---include-a-script-file
+  ########################################################################################
+
+  Include alibaba/resource-count-abc.sh
+
+  ########################################################################################
+  # https://github.com/shellspec/shellspec#function-based-mock
+  ########################################################################################
+
+  abc_regions_list() {
+    cat << EOJ
+{
+        "Regions": {
+                "Region": [
+                        {
+                                "RegionEndpoint": "ecs.aliyuncs.com",
+                                "RegionId": "cn-beijing"
+                        },
+                        {
+                                "RegionEndpoint": "ecs.aliyuncs.com",
+                                "RegionId": "cn-shanghai"
+                        },
+                        {
+                                "RegionEndpoint": "ecs.aliyuncs.com",
+                                "RegionId": "us-east-1"
+                        },
+                        {
+                                "RegionEndpoint": "ecs.aliyuncs.com",
+                                "RegionId": "us-west-1"
+                        }
+                ]
+        },
+        "RequestId": "1111"
+}
+EOJ
+  }
+
+  abc_compute_instances_list() {
+    if [ "${1}" == "us-west-1" ]; then
+      cat << EOJ
+{
+	"Instances": {
+		"Instance": [{
+				"InstanceId": "p1-111",
+				"InstanceName": "111",
+				"RegionId": "us-west-1"
+			},
+			{
+				"InstanceId": "p1-222",
+				"InstanceName": "222",
+				"RegionId": "us-west-1"
+			}
+		]
+	},
+	"NextToken": "abcd",
+	"RequestId": "1111",
+	"TotalCount": 3
+}
+EOJ
+    else
+      cat << EOJ
+{
+	"Instances": {
+		"Instance": [],
+		"NextToken": "",
+		"RequestId": "1122"
+	},
+	"TotalCount": 0
+	}
+}
+EOJ
+    fi
+  }
+
+  ########################################################################################
+  # https://github.com/shellspec/shellspec#it-specify-example---example-block
+  ########################################################################################
+
+  It 'returns a list of regions'
+    When call get_regions
+    The output should not include "Error:"
+    The variable TOTAL_REGIONS should eq 4
+  End
+
+  ####
+
+  It 'counts instances in a region'
+    When call get_instance_count "us-west-1"
+    The output should not include "Error:"
+    The variable COUNT should eq 3
+  End
+
+  It 'does not count instances in another region'
+    When call get_instance_count "us-east-1"
+    The output should not include "Error:"
+    The variable COUNT should eq 0
+  End
+
+  It 'counts resources'
+    get_regions > /dev/null 2>&1
+    reset_local_counters
+    reset_global_counters
+    #
+    When call count_resources
+    The output should include "Count"
+    The variable TOTAL_REGIONS should eq 4
+    The variable WORKLOAD_COUNT_GLOBAL should eq 3
+  End
+
+End


### PR DESCRIPTION
Uses the TotalCount of a 'aliyun ecs DescribeInstances' response.
Includes a 'get_instance_count_via_pagination()' alternative that uses NextToken.

## Description

Add Alibaba Cloud sizing script.

## Motivation and Context

Cover all the clouds.

## How Has This Been Tested?

ShellCheck and ShellSpec, and manual testing in Alibaba Cloud Shell.
I only have one instance in my personal account, so would benefit from more testing.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
