### PR TITLE
Change calculation method with awk since int variable wasn't working

### DIFF
--- a/code-security/README.md
+++ b/code-security/README.md
@@ -11,20 +11,20 @@
 #### If you have _jq_ installed (recommended)
 
 ```console
-checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
 #### If you do not have _jq_ installed
 
 ```console
-checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
 Example output:
 
 ```
 Total resource count: 160
-Code Security credit usage (total resources divded by 3): 53
+Code Security credit usage (total resources divided by 3): 53
 ```
 There are a total of 160 resources, or 53 credits to be consumed by the scanned repo
 
@@ -45,7 +45,7 @@ The resource count for the repo is 5.
 Clone all the repos under the same top-level directory. Then run the following command (replace __COMMAND__ with one of the commands from above).
 
 ```console
-for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
 ##### If you have _jq_ installed (recommended)
@@ -53,7 +53,7 @@ for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | 
 Example (using the _jq_ command):
 
 ```console
-for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
 ##### If you do not have _jq_ installed
@@ -61,14 +61,14 @@ for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json 
 Example (**without** using _jq_)
 
 ```console
-for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
 Example output:
 
 ```
 Total resource count: 277
-Code Security credit usage (total resources divded by 3): 92
+Code Security credit usage (total resources divided by 3): 92
 ```
 
 There are a total of 277 resources, or 92 credits to be consumed by the scanned repos
@@ -90,19 +90,19 @@ Then run the following command (replace __COMMAND__ with one of the commands fro
 ##### If you have _jq_ installed (recommended)
 Example (using the _jq_ command):
 
-`cat repos.txt | while read d; do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+`cat repos.txt | while read d; do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divided by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
 
 ##### If you do not have _jq_ installed
 Example (**without** using _jq_)
 
-`cat repos.txt | while read d; do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+`cat repos.txt | while read d; do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divided by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
 
 Example output:
 
 ```
 Total resource count:
 277
-Code Security credit usage (total resources divded by 3):
+Code Security credit usage (total resources divided by 3):
 92
 ```
 

--- a/code-security/README.md
+++ b/code-security/README.md
@@ -10,13 +10,13 @@
 
 #### If you have _jq_ installed (recommended)
 
-```console
+```
 checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
 #### If you do not have _jq_ installed
 
-```console
+```
 checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
@@ -30,7 +30,7 @@ There are a total of 160 resources, or 53 credits to be consumed by the scanned 
 
 
 #### On Windows/Powershell (_jq_ not required):
-```console
+```
 ((checkov -d . --download-external-modules true -o json)| convertFrom-Json).summary.resource_count
 5
 ```
@@ -44,7 +44,7 @@ The resource count for the repo is 5.
 
 Clone all the repos under the same top-level directory. Then run the following command (replace __COMMAND__ with one of the commands from above).
 
-```console
+```
 for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
@@ -52,7 +52,7 @@ for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | 
 
 Example (using the _jq_ command):
 
-```console
+```
 for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 
@@ -60,7 +60,7 @@ for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json 
 
 Example (**without** using _jq_)
 
-```console
+```
 for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divided by 3): "}; printf"%0.0f\n", pc}';
 ```
 

--- a/code-security/README.md
+++ b/code-security/README.md
@@ -10,26 +10,30 @@
 
 #### If you have _jq_ installed (recommended)
 
-`checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+```console
+checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+```
 
 #### If you do not have _jq_ installed
 
-`checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+```console
+checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+```
 
 Example output:
 
 ```
-Total resource count:
-160
-Code Security credit usage (total resources divded by 3):
-53
+Total resource count: 160
+Code Security credit usage (total resources divded by 3): 53
 ```
 There are a total of 160 resources, or 53 credits to be consumed by the scanned repo
 
 
 #### On Windows/Powershell (_jq_ not required):
-`((checkov -d . --download-external-modules true -o json)| convertFrom-Json).summary.resource_count`
-`5`
+```console
+((checkov -d . --download-external-modules true -o json)| convertFrom-Json).summary.resource_count
+5
+``
 
 The resource count for the repo is 5.
 
@@ -40,27 +44,31 @@ The resource count for the repo is 5.
 
 Clone all the repos under the same top-level directory. Then run the following command (replace __COMMAND__ with one of the commands from above).
 
-`for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+```console
+for d in $(ls); do cd $d; COMMAND; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+```
 
 ##### If you have _jq_ installed (recommended)
 
 Example (using the _jq_ command):
 
-`for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+```console
+for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | jq 'if type=="array" then . else [.] end | [.[].summary.resource_count] | add'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+```
 
 ##### If you do not have _jq_ installed
 
 Example (**without** using _jq_)
 
-`for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{print "Total resource count:"};{print int};{print "Code Security credit usage (total resources divded by 3):"};{printf "%0.0f\n",int/3 " credits "}'`
+```console
+for d in $(ls); do cd $d; checkov -d . --download-external-modules true -o json | grep resource_count | awk '{print substr($2, 0, length($2) - 1)}' | awk '{s += $1} END {print s}'; cd -; done | awk '{s += $1} END {print s}' | awk '{bc=$1 ; pc=($1/3); printf "Total resource count: " ; printf"%0.0f\n", bc ; {printf "Code Security credit usage (total resources divded by 3): "}; printf"%0.0f\n", pc}';
+```
 
 Example output:
 
 ```
-Total resource count:
-277
-Code Security credit usage (total resources divded by 3):
-92
+Total resource count: 277
+Code Security credit usage (total resources divded by 3): 92
 ```
 
 There are a total of 277 resources, or 92 credits to be consumed by the scanned repos

--- a/code-security/README.md
+++ b/code-security/README.md
@@ -33,7 +33,7 @@ There are a total of 160 resources, or 53 credits to be consumed by the scanned 
 ```console
 ((checkov -d . --download-external-modules true -o json)| convertFrom-Json).summary.resource_count
 5
-``
+```
 
 The resource count for the repo is 5.
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Switch the AWK calculation method to awk '{bc=$1 ; pc=($1/3); ... 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I tried the command that was in the repo with int but it wasn't working for me.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I tested on my WSL2 on windows10 with zsh and bash with and without JQ
<!--- Include details of your testing environment, and the tests you ran to -->
I tested on my WSL2 on windows10 with zsh and bash with and without JQ
<!--- see how your change affects other areas of the code, etc. -->
No impacts

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
