### PR TITLE
Added support for AWS Profiles

### DIFF
--- a/aws/resource-count-aws.sh
+++ b/aws/resource-count-aws.sh
@@ -68,6 +68,39 @@ else
    WITH_DATA="false"
 fi
 
+
+##########################################################################################
+## Optionally pass an AWS profile to use. Profiles are available at ~/.aws/config (Linux & Mac) or %USERPROFILE%\.aws\config (Windows)
+##########################################################################################
+
+echo ">>> Profiles are available at ~/.aws/config (Linux & Mac) or %USERPROFILE%\.aws\config (Windows)"
+
+ORIGINAL_AWS_PROFILE_ENV=$(printenv AWS_PROFILE)
+echo "Setting AWS_PROFILE environment variable for this run"
+echo ""
+
+echo "Available profiles:"
+INSTALLED_PROFILES=$(aws configure list-profiles)
+echo "$INSTALLED_PROFILES"
+echo ""
+
+
+INSTALLED_PROFILES_COUNT=$(aws configure list-profiles | wc -l)
+
+if [ ${INSTALLED_PROFILES_COUNT} -eq 1 ]; then
+  echo ""
+  echo ">>> Only one profile available. Running with it."
+  export AWS_PROFILE=${INSTALLED_PROFILES}
+else
+  echo ">>> Please enter the desired AWS configuration profile to use."
+  read AWS_PROFILE_INPUT
+  while [[ $AWS_PROFILE_INPUT = "" ]]; do
+    echo "AWS Configuration profile cannot be empty"
+    read AWS_PROFILE_INPUT
+  done
+  export AWS_PROFILE=${AWS_PROFILE_INPUT}
+fi
+
 ##########################################################################################
 ## Utility functions.
 ##########################################################################################


### PR DESCRIPTION
## Description

This update will check for available profiles and prompt the user to enter a profile name if more than one profile is available. If there is only one, the script will carry on as usual.

## Motivation and Context

In some cases, the default profile is not able to be used with temporary credentials issued through a login provider such as Okta or OneLogin. 

## How Has This Been Tested?

Used this updated script to pull information from over 50 accounts via profiles. 

## Screenshots (if appropriate)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
