### PR TITLE
update resource-count-oci.sh - get_compartments

### DIFF
--- a/oci/resource-count-oci.sh
+++ b/oci/resource-count-oci.sh
@@ -75,7 +75,7 @@ oci_load_balancer_list(){
 ####
 
 get_compartments() {
-  COMPARTMENTS=($(oci_compartments_list | jq -r '.data[]."compartment-id"' 2>/dev/null))
+  COMPARTMENTS=($(oci_compartments_list | jq -r '.data[]."id"' 2>/dev/null))
   TOTAL_COMPARTMENTS=${#COMPARTMENTS[@]}
 }
 


### PR DESCRIPTION
## Description

This issue was found using the script in a customer environment. And I was able to replicate it on a trial OCI account.

In the 78 line the script will parse the compartment-id, and it appears that it creates and issue listing just the root compartment, considering each child compartment shares the same parent "compartment-id", we could see the script generating a list of "0 resources". 

The proposed change is to parse the child compartment id ("id" instead "compartment-id"), avoinding a loop just to the root compartment, because the script is looping against the root compartment ("compartment-id" of a child compartment) instead the child compartments ("id" key).


## Motivation and Context

This change intent to solve cases which the oci script would return 0 resources, because it is not looping against the child "id" compartment:

~~~json
{
  "data": [
    {
      "compartment-id": "ocid1.tenancy.oc1..<root_id>",
      "defined-tags": {},
      "description": "<description",
      "freeform-tags": {},
      "id": "ocid1.compartment.oc1..<id>",
      "inactive-status": null,
      "is-accessible": null,
      "lifecycle-state": "ACTIVE",
      "name": "ManagedCompartmentForPaaS",
      "time-created": "2022-08-03T01:56:35.073000+00:00"
    },
    {
      "compartment-id": "ocid1.tenancy.oc1..<id>",
      "defined-tags": {
        "Oracle-Tags": {
          "CreatedBy": "default/ari.oliveira@gmail.com",
          "CreatedOn": "2022-08-05T12:17:01.686Z"
        }
      },
      "description": "Non-Production Compartment",
      "freeform-tags": {},
      "id": "ocid1.compartment.oc1..<id>",
      "inactive-status": null,
      "is-accessible": null,
      "lifecycle-state": "ACTIVE",
      "name": "NonProduction",
      "time-created": "2022-08-05T12:17:02.079000+00:00"
    },
    {
      "compartment-id": "ocid1.tenancy.oc1..<root_id>",
      "defined-tags": {
        "Oracle-Tags": {
          "CreatedBy": "default/ari.oliveira@gmail.com",
          "CreatedOn": "2022-08-05T13:03:43.637Z"
        }
     }
  }
  ]
}
~~~

When we have nested compartments, the script is listing just the root compartment, we need to list the child compartments, because the root compartment does not contain any resources usually.

## How Has This Been Tested?

I've tested on a trial OCI account. I suggest that the change could be tested in a larger and more complex environment to double check.

## Screenshots (if appropriate)

Before the change (looping against the same compartment):
~~~sh
###################################################################################
Totals
  Count of Compute Instances: 0
  Count of Bare Metal VM DB Systems: 0
  Count of Load Balancers: 0
Total billable resources: 0
###################################################################################
~~~

After the change (looping against the first level child compartments):
~~~sh
###################################################################################
Processing Compartment: ocid1.compartment.oc1..<id>
  Count of Compute Instances: 1
 Count of Bare Metal VM Database Systems : 0
 Count of Load Balancers : 0
Total billable resources for Compartment: 1
###################################################################################

###################################################################################
Totals
  Count of Compute Instances: 1
  Count of Bare Metal VM DB Systems: 0
  Count of Load Balancers: 0
Total billable resources: 1
###################################################################################
~~~

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
