### PR TITLE
Update resource-count-abc.sh

### DIFF
--- a/alibaba/resource-count-abc.sh
+++ b/alibaba/resource-count-abc.sh
@@ -118,7 +118,7 @@ count_resources() {
     echo "###################################################################################"
     echo "Processing Region: ${REGION}"
 
-    RESOURCE_COUNT=$(get_instance_count "${REGION}")
+    RESOURCE_COUNT=$(get_instance_count_via_pagination "${REGION}") 
     COMPUTE_INSTANCES_COUNT=$((COMPUTE_INSTANCES_COUNT + RESOURCE_COUNT))
     echo "  Count of Compute Instances: ${COMPUTE_INSTANCES_COUNT}"
 


### PR DESCRIPTION
Due to a possible bug in the AliCloud API JSON, the "Total Count" collected by the get_instance_count() function would always return 0 count. Thus, I've updated the script to leverage get_instance_count_via_pagination() instead.
