### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,7 +13,7 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: run shellcheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -13,7 +13,7 @@ jobs:
     name: shellspec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: install shellspec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes
       - name: run shellspec using bash


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions